### PR TITLE
Fixed Bower.json. One too many commas.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "payment",
     "webfont",
     "font",
-    "icon",
+    "icon"
   ],
   "homepage": "http://paymentfont.io",
   "dependencies": {},

--- a/bower.json
+++ b/bower.json
@@ -1,24 +1,24 @@
 {
-  "name": "paymentfont",
-  "description": "A sleek webfont containing icons of all main payment operators and methods",
-  "version": "1.0.0",
-  "keywords": [
-    "payment",
-    "webfont",
-    "font",
-    "icon"
-  ],
-  "homepage": "http://paymentfont.io",
-  "dependencies": {},
-  "devDependencies": {},
-  "license": ["OFL-1.1", "MIT"],
-  "main": [
-    "./css/*",
-    "./fonts/*"
-  ],
-  "ignore": [
-    "*/.*",
-    "*.png",
-    "*.md"
-  ]
+	"name": "paymentfont",
+	"description": "Sleek font etc",
+	"version": "1.0.0",
+	"keywords": [
+		"payment",
+		"webfont",
+		"font",
+		"icon"
+	],
+	"homepage": "http://paymentfont.io",
+	"dependencies": {},
+	"devDependencies": {},
+	"license": ["OFL-1.1","MIT"],
+	"main": [
+		"./css/*",
+		"./fonts/*"
+	],
+	"ignore": [
+		"*/.*",
+		"*.png",
+		"*.md"
+	]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "paymentfont",
-	"description": "Sleek font etc",
+	"description": "A sleek webfont containing icons of all main payment operators and methods",
 	"version": "1.0.1",
 	"keywords": [
 		"payment",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "paymentfont",
 	"description": "Sleek font etc",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"keywords": [
 		"payment",
 		"webfont",


### PR DESCRIPTION
Bower was failing to to install PaymentFont as a dependency. Was complaining about an "Unexpected token ]". Solution was to remove a trailing comma under the "keywords" list.